### PR TITLE
Update Android target SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flutter_pomodoro
 
-A new Flutter project.
+A new Flutter project targeting Android 14 (API level 34).
 
 ## Getting Started
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.asmong.flutter_pomodoro"
-    compileSdk flutter.compileSdkVersion
+    compileSdk 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -46,7 +46,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
## Summary
- target Android 14 (API level 34)
- note this target in the README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841592d1f108325b116f92083e818f9